### PR TITLE
Use ZTD_HAS_INCLUDE_I_

### DIFF
--- a/include/ztd/platform/version.hpp
+++ b/include/ztd/platform/version.hpp
@@ -70,7 +70,7 @@
 	#else
 		#define ZTD_PLATFORM_ICONV_H_I_ ZTD_OFF
 	#endif
-#elif ZTD_PLATFORM_HAS_INCLUDE_I_(<iconv.h>)
+#elif ZTD_HAS_INCLUDE_I_(<iconv.h>)
 	#define ZTD_PLATFORM_ICONV_H_I_ ZTD_DEFAULT_ON
 #else
 	#define ZTD_PLATFORM_ICONV_H_I_ ZTD_DEFAULT_OFF


### PR DESCRIPTION
`ZTD_PLATFORM_HAS_INCLUDE_I_` is undefined and causes the build to fail if the preprocessor reaches it

This codebase already relies on `ZTD_IS_ON` from ztd::idk, so just use `ZTD_HAS_INCLUDE_I_` from idk as well.